### PR TITLE
Marshmallow 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .pytest_cache/
 coverage.xml
 .eggs
+.coverage

--- a/falcon_helpers/resources/crud.py
+++ b/falcon_helpers/resources/crud.py
@@ -222,14 +222,14 @@ class CrudBase:
         resp.status = falcon.HTTP_200
 
     def on_put(self, req, resp, **kwargs):
-        self.session.add(req.context['dto'].data)
+        self.session.add(req.context['dto'])
         self.session.flush()
 
         resp.status = falcon.HTTP_200
-        resp.text = self.schema().dump(req.context['dto'].data)
+        resp.text = self.schema().dump(req.context['dto'])
 
     def on_post(self, req, resp, **kwargs):
-        self.session.add(req.context['dto'].data)
+        self.session.add(req.context['dto'])
 
         try:
             self.session.flush()
@@ -249,7 +249,7 @@ class CrudBase:
             return
 
         resp.status = falcon.HTTP_201
-        resp.media = self.schema().dump(req.context['dto'].data).data
+        resp.media = self.schema().dump(req.context['dto'])
 
     def on_delete(self, req, resp, **kwargs):
         try:

--- a/falcon_helpers/sqla/orm.py
+++ b/falcon_helpers/sqla/orm.py
@@ -33,6 +33,8 @@ class BaseFunctions:
 
 
 class Testable:
+    __test__ = False  # Prevent pytest from collecting this class when imported in a test file
+
     testing_random_nulls = True
 
     @classmethod

--- a/falcon_helpers/tests/test_middlewares/test_marshmallow.py
+++ b/falcon_helpers/tests/test_middlewares/test_marshmallow.py
@@ -24,11 +24,12 @@ class ObjEntity(orm.BaseColumns, orm.ModelBase):
     name = sa.Column(sa.String)
 
 
-class Obj(mms.ModelSchema):
+class Obj(mms.SQLAlchemyAutoSchema):
     name = mm.fields.String()
 
     class Meta:
         model = ObjEntity
+        load_instance = True
 
 
 class WithoutSchemaResc(falcon.testing.SimpleTestResource):
@@ -42,7 +43,7 @@ class WithSchemaResc(falcon.testing.SimpleTestResource):
 class WithCustomLoader(WithSchemaResc):
     def schema_loader(self, data, req, resource, params):
         result = self.schema().load(data, session=db.session)
-        result.data.name = 'other'
+        result.name = 'other'
         return result
 
 
@@ -158,7 +159,7 @@ def test_support_default_loader(client):
 
     assert resp.status_code == 200
     assert resource.captured_req.context['_marshalled']
-    assert resource.captured_req.context['dto'].data.name == 'john'
+    assert resource.captured_req.context['dto'].name == 'john'
 
 
 def test_support_custom_loader(client):
@@ -172,7 +173,7 @@ def test_support_custom_loader(client):
 
     assert resp.status_code == 200
     assert resource.captured_req.context['_marshalled']
-    assert resource.captured_req.context['dto'].data.name == 'other'
+    assert resource.captured_req.context['dto'].name == 'other'
 
 
 def test_errors_during_loading(client):

--- a/falcon_helpers/tests/test_resources/test_crud.py
+++ b/falcon_helpers/tests/test_resources/test_crud.py
@@ -29,10 +29,11 @@ class ModelTest(Base, BaseColumns, BaseFunctions, Testable):
     other = sa.orm.relationship("ModelOther")
 
 
-class ModelSchema(ms.ModelSchema):
+class ModelSchema(ms.SQLAlchemyAutoSchema):
     class Meta:
         model = ModelTest
         exclude = ('other',)
+        load_instance = True
 
 
 class BasicCrud(CrudBase):
@@ -97,8 +98,8 @@ class TestCrudBase:
             'id': m1.id,
             'name': m1.name,
             'uni': m1.uni,
-            'created_ts': m1.created_ts.replace(tzinfo=tz.utc).isoformat(),
-            'updated_ts': m1.updated_ts.replace(tzinfo=tz.utc).isoformat(),
+            'created_ts': m1.created_ts.isoformat(),
+            'updated_ts': m1.updated_ts.isoformat(),
         }
 
     def test_crud_base_get_404_with_bad_primary_key(self, client):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'falcon==3.*',
         'falcon_multipart',
         'jinja2',
-        'marshmallow<3',
+        'marshmallow>2',
         'marshmallow-sqlalchemy',
         'pyjwt>=2.4',
         'sqlalchemy<2',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py39,310
+envlist = py310,py311
 skipsdist=True
 
 [testenv]
-passenv = TOXENV CI CODECOV_TOKEN
+passenv = TOXENV,CI,CODECOV_TOKEN
 sitepackages=false
 usedevelop=true
 extras=


### PR DESCRIPTION
- Get tests passing
- Upgrade to marshmallow 3

Note:
- New version will no longer be compatible with marshmallow 2
- Schemas will need `load_instance` set to True (this was optional before)