### PR TITLE
Falcon 4 support

### DIFF
--- a/falcon_helpers/middlewares/__init__.py
+++ b/falcon_helpers/middlewares/__init__.py
@@ -11,4 +11,3 @@ from .marshmallow import MarshmallowMiddleware
 
 from .load_user import LoadUserMiddleware
 from .parsejwt import ParseJWTMiddleware
-from .multipart import MultipartMiddleware

--- a/falcon_helpers/middlewares/multipart.py
+++ b/falcon_helpers/middlewares/multipart.py
@@ -1,5 +1,0 @@
-from falcon_multipart.middleware import MultipartMiddleware
-
-
-class MultipartMiddleware(MultipartMiddleware):
-    pass

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'cryptography',
-        'falcon==3.*',
+        'falcon>=3',
         'falcon_multipart',
         'jinja2',
         'marshmallow>=3',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     install_requires=[
         'cryptography',
         'falcon>=3',
-        'falcon_multipart',
         'jinja2',
         'marshmallow>=3',
         'marshmallow-sqlalchemy',


### PR DESCRIPTION
- **Allow falcon 4.x in setup.py**
- **Drop multipart middleware**
  - Falcon 4 has built-in multipart handling
